### PR TITLE
Fix typo in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ _Create workflows that enable you to use Continuous Integration (CI) for your pr
 [Continuous integration](https://en.wikipedia.org/wiki/Continuous_integration) can help you stick to your team’s quality standards by running tests and reporting the results on GitHub. CI tools run builds and tests, triggered by commits. The results post back to GitHub in the pull request. The goal is fewer issues in `main` and faster feedback as you work.
 
 - **Who is this for**: Developers, DevOps Engineers, new GitHub users, students, teams.
-- **What you'll learn**: What continous integration is, how to use GitHub Actions for CI, how to create a workflow that runs tests and produces test reports.
+- **What you'll learn**: What continuous integration is, how to use GitHub Actions for CI, how to create a workflow that runs tests and produces test reports.
 - **What you'll build**: We'll use [remark-lint](https://github.com/remarkjs/remark-lint) to check the consistency of Markdown files.
 - **Prerequisites**: We assume you've completed [Hello GitHub Actions](https://github.com/skills/hello-github-actions) first.
 - **How long**: This course is five steps long and takes less than two hours to complete.


### PR DESCRIPTION
### Why:

Hi it's a nice course👋 . This PR intends to fix a simple typo (`continous` -> `continuous`).

### What's being changed:

README description

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
