### PR TITLE
Add step for clicking New workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ First, let's add a workflow to lint our Markdown files in this repository.
 
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab
 1. Go to the **Actions tab**.
-1. Search for "Simple workflow".
+1. Click **New workflow**.
+1. Search for "Simple workflow" and click **Configure**.
 1. Name your workflow `ci.yml`.
 1. Update the workflow to remove all steps other than the "checkout" step.
 1. Add the following step to your workflow:


### PR DESCRIPTION
### Why:

Hi it's a nice course👋 . This PR intends to add some clarity on the operational steps.

### What's being changed:

The step description in the README. I believe that clicking "New workflow" is required before searching for "Simple workflow". 

After selecting "Actions" tab, the following screen appears.
<img width="525" alt="workflow_step_01" src="https://user-images.githubusercontent.com/1172471/173759267-a29bdbc9-b201-48bf-bb52-c6cba405387e.png">

Then click "New workflow" to show the list of workflows (which includes "Simple workflow") to click Configure.
<img width="691" alt="workflow_step_02" src="https://user-images.githubusercontent.com/1172471/173759498-fc7c2d61-500c-419a-a847-a5d66dd0a8a2.png">

### Check off the following:


- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
