### PR TITLE
Move error to a short MD file

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,7 @@ You can follow along as GitHub Actions runs your job by going to the **Actions**
 
 When the tests finish, you'll see a red X :x: or a green check mark :heavy_check_mark: in the merge box. At that point, you'll have access to logs for the build job and its associated steps.
 
-<!-- Note here: Learners -- yup, you found the error! Course maintainers -- leave the italics with * instead of _ for the error case. -->
-
-*By looking at the logs, can you identify which tests failed?* To find it, go to one of the failed builds and scrolling through the log. Look for a section that lists all the unit tests. We're looking for the name of the test with an "x".
+_By looking at the logs, can you identify which tests failed?_ To find it, go to one of the failed builds and scrolling through the log. Look for a section that lists all the unit tests. We're looking for the name of the test with an "x".
 
 <img alt="screenshot of a sample build log with the names of the tests blurred out" src=https://user-images.githubusercontent.com/16547949/65922013-e740a200-e3b1-11e9-8151-faf52c30201e.png width=400 />
 

--- a/resume.md
+++ b/resume.md
@@ -1,0 +1,27 @@
+# GitHub Teacher
+
+*Charting the knowledge of the Internet, just like Galileo charted the stars.*
+<!--
+  Note here: Learners -- yup, you found the error!
+  Course maintainers -- leave the italics with * instead of _ for the error case.
+-->
+
+## Experience
+
+### GitHub Trainer
+
+Teach all things Git, give away all the stickers, ensure world peace.
+
+### Supportocat
+
+Provide world class support to customers on the GitHub platform
+
+## Skills
+
+### Education
+
+Developed and maintained various conference talks, online training, and in-person trainings covering various topics including Git, GitHub, and Open Source.
+
+### Leadership
+
+Managed multiple asynchronous teams in the development, maintenance, and release of various web applications and websites.


### PR DESCRIPTION
Resolves https://github.com/skills/continuous-integration/issues/10

Make the Markdown lint error easier to find in a short Markdown file.