### PR TITLE
Fix markdown lint error prep in resume.md

### DIFF
--- a/resume.md
+++ b/resume.md
@@ -1,20 +1,20 @@
 # GitHub Teacher
 
-*Charting the knowledge of the Internet, just like Galileo charted the stars.*
-<!--
-  Note here: Learners -- yup, you found the error!
-  Course maintainers -- leave the italics with * instead of _ for the error case.
--->
+_Charting the knowledge of the Internet, just like Galileo charted the stars._
 
 ## Experience
 
 ### GitHub Trainer
 
-Teach all things Git, give away all the stickers, ensure world peace.
+Teach all things *Git*, give away all the stickers, ensure world peace.
+<!--
+  Note here: Learners -- yup, you found the error!
+  Course maintainers -- leave the italics with * instead of _ for the error case.
+-->
 
 ### Supportocat
 
-Provide world class support to customers on the GitHub platform
+Provide _world class support_ to customers on the GitHub platform
 
 ## Skills
 
@@ -24,4 +24,4 @@ Developed and maintained various conference talks, online training, and in-perso
 
 ### Leadership
 
-Managed multiple asynchronous teams in the development, maintenance, and release of various web applications and websites.
+Managed multiple _asynchronous teams_ in the development, maintenance, and release of various web applications and websites.


### PR DESCRIPTION
### Why:

Closes https://github.com/skills/continuous-integration/issues/26 

The Markdown lint error added in #25  is not being raised as expected. The error was added at the top of the `resume.md` file and the file does not contain any other words with the emphasis syntax ("_") making the `resume.md`  file markdown style consistent. 

![image](https://user-images.githubusercontent.com/120277121/220725306-d674f0cd-06ce-462e-9698-6bcd182057ae.png)

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
- `resume.md` file:
  - Moved the markdown lint error further down
  - Added 3 more occurrences of emphasis using the "_" syntax before and after the markdown lint error 

#### Expected Behavior:
![Screenshot 2023-02-22 at 10 48 31 AM](https://user-images.githubusercontent.com/120277121/220729080-8df55c7f-18ef-4cc7-a9da-b15ace731c64.png)

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
